### PR TITLE
Update GitHub links for SynapseGrid Labs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security report
-    url: https://github.com/trentdoney/TotalReClaw/security/advisories/new
+    url: https://github.com/SynapseGrid-Labs/TotalReClaw/security/advisories/new
     about: Please report security-sensitive issues through GitHub private advisories.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TotalReClaw
 
-[![CI](https://github.com/trentdoney/TotalReClaw/actions/workflows/ci.yml/badge.svg)](https://github.com/trentdoney/TotalReClaw/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/trentdoney/TotalReClaw)](LICENSE)
+[![CI](https://github.com/SynapseGrid-Labs/TotalReClaw/actions/workflows/ci.yml/badge.svg)](https://github.com/SynapseGrid-Labs/TotalReClaw/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/SynapseGrid-Labs/TotalReClaw)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.14.0-339933?logo=nodedotjs&logoColor=white)](package.json)
 
 ![TotalReClaw header](docs/images/totalreclaw-header-vip.svg)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Do not open public issues for suspected vulnerabilities.
 
 Report security problems through GitHub private vulnerability reporting:
 
-- `https://github.com/trentdoney/TotalReClaw/security/advisories/new`
+- `https://github.com/SynapseGrid-Labs/TotalReClaw/security/advisories/new`
 
 Include:
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5,7 +5,7 @@
   "version": "0.3.0",
   "author": "Trent Doney",
   "license": "MIT",
-  "homepage": "https://github.com/trentdoney/TotalReClaw",
+  "homepage": "https://github.com/SynapseGrid-Labs/TotalReClaw",
   "skills": [
     "skills/TotalReClaw"
   ],

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "main": "index.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trentdoney/TotalReClaw.git"
+    "url": "git+https://github.com/SynapseGrid-Labs/TotalReClaw.git"
   },
   "bugs": {
-    "url": "https://github.com/trentdoney/TotalReClaw/issues"
+    "url": "https://github.com/SynapseGrid-Labs/TotalReClaw/issues"
   },
-  "homepage": "https://github.com/trentdoney/TotalReClaw#readme",
+  "homepage": "https://github.com/SynapseGrid-Labs/TotalReClaw#readme",
   "license": "MIT",
   "author": "Trent Doney",
   "keywords": [


### PR DESCRIPTION
## Summary

Updates public GitHub owner links after transferring TotalReClaw to SynapseGrid Labs.

Changed only public metadata links in:
- README badges
- package repository/bugs/homepage metadata
- OpenClaw plugin homepage
- security advisory link
- issue-template security contact link

## Verification

- Local `npm run verify` passed on the transferred org checkout.
- Local staged-diff security scan found no credentials, private infrastructure references, or OpsVault paths introduced.
- Remaining audit finding is tracked separately: moderate advisory chain through `openclaw` / `@anthropic-ai/sdk`.

## Notes

CODEOWNERS was not changed because `SynapseGrid-Labs/maintainers` returned 404 / was not visible through the available token, so changing CODEOWNERS would risk a broken owner reference.